### PR TITLE
Allow overridable tokenizer parameters.

### DIFF
--- a/document.go
+++ b/document.go
@@ -111,7 +111,7 @@ func NewDocument(text string, opts ...DocOpt) (*Document, error) {
 		doc.sentences = segmenter.segment(text)
 	}
 	if base.Tokenize || base.Tag || base.Extract {
-		tokenizer := newIterTokenizer()
+		tokenizer := NewIterTokenizer()
 		doc.tokens = append(doc.tokens, tokenizer.tokenize(text)...)
 	}
 	if base.Tag || base.Extract {

--- a/extract.go
+++ b/extract.go
@@ -270,7 +270,7 @@ func assignLabels(tokens []*Token, entity *EntityContext) []string {
 }
 
 func makeCorpus(data []EntityContext, tagger *perceptronTagger) featureSet {
-	tokenizer := newIterTokenizer()
+	tokenizer := NewIterTokenizer()
 	corpus := featureSet{}
 	for i := range data {
 		entry := &data[i]


### PR DESCRIPTION
This PR changes `iterTokenizer` struct to contain the parameters that can be overriden. This will allow future changes to `NewDocument` that use a custom tokenizer.

Will help with issue #41 and #32

Test: existing unit test