### PR TITLE
Introduce Tokenizer interface

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -2,6 +2,7 @@ package prose
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -10,6 +11,22 @@ func BenchmarkDoc(b *testing.B) {
 	text := string(content)
 	for n := 0; n < b.N; n++ {
 		_, err := NewDocument(text)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func CustomTokenizer(b *testing.B) {
+	content := readDataFile(filepath.Join(testdata, "sherlock.txt"))
+    tok := NewIterTokenizer(
+        UsingSanitizer(strings.NewReplacer()), // Disable sanitizer
+        UsingPrefixes([]string{"(", `"`, "[", "'"}),
+        UsingSuffixes([]string{",", ")", `"`, "]", "!", ";", ".", "?", ":", "'"}),
+    )
+	text := string(content)
+	for n := 0; n < b.N; n++ {
+		_, err := NewDocument(text, UsingTokenizer(tok))
 		if err != nil {
 			panic(err)
 		}

--- a/extract.go
+++ b/extract.go
@@ -269,12 +269,11 @@ func assignLabels(tokens []*Token, entity *EntityContext) []string {
 	return history
 }
 
-func makeCorpus(data []EntityContext, tagger *perceptronTagger) featureSet {
-	tokenizer := NewIterTokenizer()
+func makeCorpus(data []EntityContext, tagger *perceptronTagger, tokenizer Tokenizer) featureSet {
 	corpus := featureSet{}
 	for i := range data {
 		entry := &data[i]
-		tokens := tagger.tag(tokenizer.tokenize(entry.Text))
+		tokens := tagger.tag(tokenizer.Tokenize(entry.Text))
 		history := assignLabels(tokens, entry)
 		for _, element := range extractFeatures(tokens, history) {
 			corpus = append(corpus, element)
@@ -283,8 +282,7 @@ func makeCorpus(data []EntityContext, tagger *perceptronTagger) featureSet {
 	return corpus
 }
 
-func extracterFromData(data []EntityContext, tagger *perceptronTagger) *entityExtracter {
-	corpus := makeCorpus(data, tagger)
+func extracterFromData(corpus featureSet) *entityExtracter {
 	encoding := encode(corpus)
 	cInv := 1.0 / float64(encoding.cardinality)
 

--- a/model.go
+++ b/model.go
@@ -18,8 +18,14 @@ type DataSource func(model *Model)
 
 // UsingEntities creates a NER from labeled data.
 func UsingEntities(data []EntityContext) DataSource {
+	return UsingEntitiesAndTokenizer(data, NewIterTokenizer())
+}
+
+// UsingEntities creates a NER from labeled data and custom tokenizer.
+func UsingEntitiesAndTokenizer(data []EntityContext, tokenizer Tokenizer) DataSource {
 	return func(model *Model) {
-		model.extracter = extracterFromData(data, model.tagger)
+		corpus := makeCorpus(data, model.tagger, tokenizer)
+		model.extracter = extracterFromData(corpus)
 	}
 }
 

--- a/segment_test.go
+++ b/segment_test.go
@@ -26,7 +26,7 @@ func readDataFile(path string) []byte {
 func makeSegmenter(text string) (*Document, error) {
 	return NewDocument(
 		text,
-		WithTokenization(false),
+		UsingTokenizer(nil),
 		WithTagging(false),
 		WithExtraction(false))
 }

--- a/tokenize.go
+++ b/tokenize.go
@@ -7,6 +7,10 @@ import (
 	"unicode/utf8"
 )
 
+type Tokenizer interface {
+	Tokenize(string) []*Token
+}
+
 // iterTokenizer splits a sentence into words.
 type iterTokenizer struct {
 	specialRE *regexp.Regexp
@@ -129,7 +133,7 @@ func (t *iterTokenizer) doSplit(token string) []*Token {
 }
 
 // tokenize splits a sentence into a slice of words.
-func (t *iterTokenizer) tokenize(text string) []*Token {
+func (t *iterTokenizer) Tokenize(text string) []*Token {
 	tokens := []*Token{}
 
 	clean, white := t.sanitizer.Replace(text), false


### PR DESCRIPTION
This PR allows the user to provide a different tokenizer.

Users can specify their own Tokenizer in the DocOpts. This replaces the
boolean Tokenize option (set Tokenizer to nil to disable.)

Currently only IterTokenizer is provided, which can be customized with
its own Using options. `func Tokenize` becomes public to allow users to
provide their own implementation and completely replace IterTokenizer.

Model and Extractor need to use the same Tokenizer as Document, so this
PR modifies those APIs to be consistent.

(Also separating makeCorpus from extracterFromData to simplify parameter passing.)


This solves issue #41 and #32