### PR TITLE
Add UsingIsUnsplittable to extend IterTokenizer's isSpecial

### DIFF
--- a/tokenize.go
+++ b/tokenize.go
@@ -7,6 +7,8 @@ import (
 	"unicode/utf8"
 )
 
+type TokenTester func(string) bool
+
 // iterTokenizer splits a sentence into words.
 type iterTokenizer struct {
 	specialRE *regexp.Regexp
@@ -14,9 +16,17 @@ type iterTokenizer struct {
 	suffixes  []string
 	prefixes  []string
 	emoticons map[string]int
+	isUnsplittable TokenTester
 }
 
 type TokenizerOptFunc func(*iterTokenizer)
+
+// UsingIsUnsplittableFN gives a function that tests whether a token is splittable or not.
+func UsingIsUnsplittable(x TokenTester) TokenizerOptFunc {
+	return func(tokenizer *iterTokenizer) {
+		tokenizer.isUnsplittable = x
+	}
+}
 
 // Use the provided special regex for unsplittable tokens.
 func UsingSpecialRE(x *regexp.Regexp) TokenizerOptFunc {
@@ -59,6 +69,7 @@ func NewIterTokenizer(opts ...TokenizerOptFunc) *iterTokenizer {
 
 	// Set default parameters
 	tok.emoticons = emoticons
+	tok.isUnsplittable = func(_ string) bool { return false }
 	tok.prefixes = prefixes
 	tok.sanitizer = sanitizer
 	tok.specialRE = internalRE
@@ -81,7 +92,7 @@ func addToken(s string, toks []*Token) []*Token {
 
 func (t *iterTokenizer) isSpecial(token string) bool {
 	_, found := t.emoticons[token]
-	return found || t.specialRE.MatchString(token)
+	return found || t.specialRE.MatchString(token) || t.isUnsplittable(token)
 }
 
 func (t *iterTokenizer) doSplit(token string) []*Token {


### PR DESCRIPTION
Allows users to profive a custom `TokenTester func(string) bool` to
test their own unsplittable tokens (ie: jira ticket numbers, date and time, etc.)