### PR TITLE
add splitCase field and implementation

### DIFF
--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -181,6 +181,13 @@ func TestTokenizationTwitter(t *testing.T) {
 	checkCase(t, doc, expected, "TokenizationWebParagraph(5)")
 }
 
+func TestTokenizationSplitCases(t *testing.T) {
+	tokenizer := NewIterTokenizer(UsingSplitCases([]string{"("}))
+	tokens := tokenizer.Tokenize("amount($)")
+	expected := []string{"amount", "(", "$", ")"}
+	checkTokens(t, tokens, expected, "TokenizationSplitCases(custom-found)")
+}
+
 func TestTokenizationContractions(t *testing.T) {
 	tokenizer := NewIterTokenizer()
 	tokens := tokenizer.Tokenize("He's happy")


### PR DESCRIPTION
splitCase should add up to the fields of iterTokenizer which already exist, like contractions and prefixes. It should work for cases which any of the fields could make the tokenization work. 

A good example would be the case of "amount($)". In this scanario ")" works as suffix but "(" is not a prefix as there's no space betwen the tokens. Using "(" as space would work and the user would not be obliged to write a regex as it seems a bit overkill for sure a simple case.

Also added test for this case.