### PR TITLE
Allow multiple match indexes

### DIFF
--- a/tokenize.go
+++ b/tokenize.go
@@ -210,7 +210,7 @@ var sanitizer = strings.NewReplacer(
 	"&rsquo;", "'")
 var contractions = []string{"'ll", "'s", "'re", "'m", "n't"}
 var suffixes = []string{",", ")", `"`, "]", "!", ";", ".", "?", ":", "'"}
-var prefixes = []string{"$", "(", `"`, "["}
+var prefixes = []string{"$", "(", `"`, "[", ":"}
 var emoticons = map[string]int{
 	"(-8":         1,
 	"(-;":         1,

--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -201,6 +201,16 @@ func TestTokenizationContractions(t *testing.T) {
 	checkTokens(t, tokens, expected, "TokenizationContraction(custom-missing)")
 }
 
+func TestTokenizationMultipleContractions(t *testing.T) {
+	tokenizer := NewIterTokenizer()
+	tokens := tokenizer.Tokenize("He's're")
+	for _, token := range tokens {
+		t.Logf("token: %v\n", token)
+	}
+	expected := []string{"He", "'s", "'re"}
+	checkTokens(t, tokens, expected, "TokenizationContraction(default-found)")
+}
+
 func BenchmarkTokenization(b *testing.B) {
 	in := readDataFile(filepath.Join(testdata, "sherlock.txt"))
 	text := string(in)

--- a/utilities.go
+++ b/utilities.go
@@ -72,15 +72,16 @@ func hasAnySuffix(s string, suffixes []string) bool {
 	return false
 }
 
-func hasAnyIndex(s string, suffixes []string) int {
+func hasAnyIndex(s string, suffixes []string) []int {
+	var idxs []int
 	n := len(s)
 	for _, suffix := range suffixes {
 		idx := strings.Index(s, suffix)
 		if idx >= 0 && n > len(suffix) {
-			return idx
+			idxs = append(idxs, idx)
 		}
 	}
-	return -1
+	return idxs
 }
 
 func nSuffix(word string, length int) string {


### PR DESCRIPTION
still trying to fix the problem raised at #66.

Now checking all matching indexes on `hasAnyIndex(lower, t.contractions)`. The idea is to not discard multiple contracitions.
Although it's not commom to have more than one contraction in the same token, it's something possible and, more importantly, it opens room for more improvements as in the #71. Both pull requests are supposed to work together, but work separately as well.

Also added tests for the changes.

Also also added : to default prefixes as it was in defaut sufixes. Depending on the text, ":" could be both in the begining and ending of a token and would be nice to be prepared for both.