### PR TITLE
Adds ModelFromFS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jdkato/prose/v3
 
-go 1.13
+go 1.16
 
 require (
 	github.com/neurosnap/sentences v1.0.6 // indirect

--- a/model_test.go
+++ b/model_test.go
@@ -1,6 +1,8 @@
 package prose
 
 import (
+	"embed"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,5 +26,42 @@ func TestModelFromDisk(t *testing.T) {
 	model = ModelFromDisk(temp)
 	if model.Name != "temp" {
 		t.Errorf("ModelFromDisk() expected = temp, got = %v", model.Name)
+	}
+}
+
+//go:embed testdata/PRODUCT
+var embeddedModel embed.FS
+
+func TestModelFromFS(t *testing.T) {
+	err := fs.WalkDir(embeddedModel, ".", func(path string, d fs.DirEntry, err error) error {
+		//fmt.Printf("Walking dir %s, err %s\n", path, err)
+		return nil
+	})
+
+	// Load the embedded PRODUCT model
+	model := ModelFromFS("PRODUCT", embeddedModel)
+	if model.Name != "PRODUCT" {
+		t.Errorf("ModelFromFS() expected = PRODUCT, got = %v", model.Name)
+	}
+
+	doc, err := NewDocument("Windows 10 is an operating system",
+		UsingModel(model))
+
+	if err != nil {
+		t.Errorf("Failed to create doc with ModelFromFS")
+	}
+
+	ents := doc.Entities()
+
+	if len(ents) != 1 {
+		t.Fatalf("Expected 1 entity, got %v", ents)
+	}
+
+	if ents[0].Text != "Windows 10" {
+		t.Errorf("Expected to find entity 'Windows 10' with ModelFromFS, got = %v", ents[0].Text)
+	}
+
+	if ents[0].Label != "PRODUCT" {
+		t.Errorf("Expected to tab entity with PRODUCT, got = %v", ents[0].Label)
 	}
 }

--- a/utilities.go
+++ b/utilities.go
@@ -3,7 +3,7 @@ package prose
 import (
 	"bytes"
 	"encoding/gob"
-	"os"
+	"io/fs"
 	"path"
 	"strconv"
 	"strings"
@@ -46,10 +46,8 @@ func getAsset(folder, name string) *gob.Decoder {
 	return gob.NewDecoder(bytes.NewReader(b))
 }
 
-func getDiskAsset(path string) *gob.Decoder {
-	f, err := os.Open(path)
-	checkError(err)
-	return gob.NewDecoder(f)
+func getDiskAsset(file fs.File) *gob.Decoder {
+	return gob.NewDecoder(file)
 }
 
 func hasAnyPrefix(s string, prefixes []string) bool {


### PR DESCRIPTION
Follow-up to https://github.com/jdkato/prose/issues/76

I added the model name as an input to `ModelFromFS`, because the FS we get back from `embed` will be rooted at the embedding package. Using the tests as an example, if we embed `testdata/PRODUCT`, we need to traverse down through the `testdata` and `PRODUCT` directories before we can find the model. By passing the model name we're looking for, we'll be able to locate and load the right model regardless of how deeply its nested relative to the embedding package.

Also re-uses the FS-based code for `ModelFromDisk` without any functional changes.

Let me know if there's anything else to do for this PR and I'll make updates.

Thanks!